### PR TITLE
[#110347526, #110265428] Adds Orders Controller

### DIFF
--- a/OneShipStationPlugin.php
+++ b/OneShipStationPlugin.php
@@ -49,8 +49,20 @@ class OneShipStationPlugin extends BasePlugin {
 
     public function dropTables() {}
 
-    public function registerSiteRoutes() {
-        return array();
-    }
+    /*
+     * WARNING: Do not register any routes that ShipStation will use here.
+     *          ShipStation sends a parameter `action` with every request, which collides with
+     *          Craft's action request handling. Therefore, any request from ShipStation MUST
+     *          be routed as an action request using the actionTrigger defined in config/general (default: "actions").
+     *
+     *          `_checkRequestType()` in craft/app/services/HttpRequestService.php determines the request type in this order:
+     *
+     *          1. the first URL segment matches config's actionTrigger
+     *          2. the GET or POST param `action` is set at not null
+     *          3. the request is a special path
+     *
+     *          If any of these are true, Craft handles routing and never checks for plugins' registerSiteRoutes()
+     */
+    public function registerSiteRoutes() { return []; }
 
 }

--- a/README.md
+++ b/README.md
@@ -38,3 +38,36 @@ Be sure to add `craft/plugins/oneshipstation` to your other project's gitignore,
 # .gitignore
 craft/plugins/oneshipstation
 ```
+
+## ShipStation Configuration
+
+Once you have configured your Craft application's OneShipStation, you will need to complete the proces by configuring your [ShipStation "Custom Store" integration](https://help.shipstation.com/hc/en-us/articles/205928478-ShipStation-Custom-Store-Development-Guide#3a).
+
+There, you will be required to provide a user name, password, and a URL that ShipStation will use to contact your application.
+
+### Installation Requirements
+
+#### "Action" naming collision
+
+ShipStation and Craft have a routing collision due to their combined use of the parameter `action`.
+ShipStation sends requests using `?action=export` to read order data, and `?action=shipnotify` to update shipping data.
+This conflicts with Craft's reserved word `action` to describe an ["action request"](https://craftcms.com/docs/plugins/controllers#how-controller-actions-fit-into-routing),
+which is designed to allow for easier routing configuration.
+
+Because of this, the route given to ShipStation for their Custom Store integration _must_ begin with your Craft config's "actionTrigger" (in `craft/config/general.php`), which defaults to the string "actions".
+
+For example, if your actionTrigger is set to "actions", the URL you prove to ShipStation should be:
+
+```
+https://{yourdomain.com}/actions/oneShipStation/orders/process
+```
+
+If your actionTrigger is set to "myCustomActionTrigger", it would be:
+
+```
+https://{yourdomain.com}/myCustomActionTrigger/oneShipStation/orders/process
+```
+
+#### Case Sensitivity
+
+Note that this is case sensitive. Due to Craft's segment matching, the `oneShipStation` segment in the URL _must_ be `oneShipStation`, not `oneshipstation` or `ONESHIPSTATION`.

--- a/controllers/OneShipStation_OrdersController.php
+++ b/controllers/OneShipStation_OrdersController.php
@@ -1,0 +1,41 @@
+<?php
+namespace Craft;
+
+class Oneshipstation_OrdersController extends BaseController
+{
+    protected $allowAnonymous = true;
+
+    /**
+     * ShipStation will hit this action for processing orders, both POSTing and GETting.
+     *   ShipStation will send a GET param 'action' of either shipnotify or export.
+     *   If this is not found or is any other string, this will throw a 400 exception.
+     *
+     * @param array $variables, containing key 'fulfillmentService'
+     * @throws HttpException for malformed requests
+     */
+    public function actionProcess(array $variables=[]) {
+        switch (craft()->request->getQuery('action')) {
+            case 'export':
+                return $this->getOrders();
+            case 'shipnotify':
+                return $this->postShipment();
+            default:
+                throw new HttpException(400);
+        }
+    }
+
+    private function authenticate() {
+        //TODO
+        return true;
+    }
+
+    protected function getOrders() {
+        //TODO
+        echo 'getting orders';exit();
+    }
+
+    protected function postShipment() {
+        //TODO
+        echo 'posting shipment';exit();
+    }
+}


### PR DESCRIPTION
This took quite a while because of a collision between Craft's action request routing and ShipStation's payload when making requests. High level explanation in the README below, including instructions for how to handle it, and a slightly more technical explanation in the plugin's `registerSiteRoutes()` docblock. 

This makes [#110263936](https://www.pivotaltracker.com/story/show/110263936) even more important, where we print out the URL needed to give ShipStation very clearly, since, according to my research, our routing is _extremely_ inflexible due to this action thing.
