### PR TITLE
[#121591205] dramatically improves speed for export

### DIFF
--- a/controllers/OneShipStation_OrdersController.php
+++ b/controllers/OneShipStation_OrdersController.php
@@ -79,7 +79,7 @@ class Oneshipstation_OrdersController extends BaseController
             $pageSize = 25;
         }
 
-        $numPages = ceil($criteria->limit(null)->count() / $pageSize);
+        $numPages = ceil($this->getEfficientCount($criteria) / $pageSize);
         $pageNum = craft()->request->getParam('page');
         if (!is_numeric($pageNum) || $pageNum < 1) {
             $pageNum = 1;
@@ -89,6 +89,23 @@ class Oneshipstation_OrdersController extends BaseController
         $criteria->offset = ($pageNum - 1) * $pageSize;
 
         return $numPages;
+    }
+
+    /**
+     * $criteria->count() builds all objects and calls count($objects).
+     * that's terrible. passing true as the second param gets only IDs.
+     * this is the best quick solution i could find without modifying craft source.
+     * ideally, $criteria->count() would execute a `SELECT COUNT(*) FROM ...` to
+     * avoid even needing the big array of IDs.
+     *
+     * TODO: get Craft to update ElementCriteriaModel::count()
+     *
+     * @param ElementCriteriaModel
+     * @return Int
+     */
+    protected function getEfficientCount($criteria) {
+        $elements = craft()->elements->findElements($criteria->limit(null), true);
+        return count($elements);
     }
 
     /**


### PR DESCRIPTION
`ElementCriteriaModel::count()` looks like this:

```
public function count()
{
    return count($this->find());
}
```

This means that counting the total number of orders that have a status (ie, are not carts) requires retrieving data for and then instantiating _every single order_, throwing them into an array, and then counting the array. After the big rush yesterday, this means we're building over 9000 orders just to get a count of orders, which requires lots of memory and lots of time, causing timeouts roughly 4 requests out of 5.

This PR makes a new method of counting, which, rather than modifying Craft's 638-line `ElementsService::buildElementsQuery()` to use `SELECT COUNT(*) FROM ...`, fetches only the IDs of the orders, throws them into an array, and counts the array:

```
protected function getEfficientCount($criteria) {
    //the second parameter in findElements() will return only IDs if true
    $elements = craft()->elements->findElements($criteria->limit(null), true);
    return count($elements);
}
```

In my very unscientific testing, in an environment with 239 orders, this brought the time needed for shipstations `export` request from an average of 1700ms to 700ms.
