### PR TITLE
Fixes a PHP notice `Only variables can be passed by reference`

### DIFF
--- a/services/OneShipStation_ShippingLogService.php
+++ b/services/OneShipStation_ShippingLogService.php
@@ -12,7 +12,8 @@ class OneShipStation_ShippingLogService extends BaseApplicationComponent {
      */
     public function logShippingInformation($order, $attributes) {
         $infoMatrix = craft()->fields->getFieldByHandle('shippingInfo');
-        $blockType  = array_shift(craft()->matrix->getBlockTypesByFieldId($infoMatrix->id));
+        $blockTypes = craft()->matrix->getBlockTypesByFieldId($infoMatrix->id);
+        $blockType  = array_shift($blockTypes);
 
         if ($infoMatrix && $blockType && $order) {
             $block = new MatrixBlockModel();


### PR DESCRIPTION
Reads block types into a variable and then shifts the array. Using the method call within array_shift was causing an PHP notice about passing by reference.