### PR TITLE
Bugfix/cleanup

### DIFF
--- a/OneShipStationPlugin.php
+++ b/OneShipStationPlugin.php
@@ -36,14 +36,16 @@ class OneShipStationPlugin extends BasePlugin {
 
         // require PHP 5.4+
         if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 50400) {
-            Craft::log('One ShipStation requires PHP 5.4+ in order to run.', LogLevel::Error);
-            return false;
+            throw new Exception('One ShipStation requires PHP 5.4+ in order to run.');
         }
 
         // require Craft Commerce 1.0+
         if (!($commerce = craft()->plugins->getPlugin('commerce')) || version_compare($commerce->getVersion(), '1.0', '<')) {
-            Craft::log('One ShipStation requires Craft Commerce 1.0+.', LogLevel::Error);
-            return false;
+            throw new Exception('One ShipStation requires Craft Commerce 1.0+.');
+        }
+
+        if (!extension_loaded('xml')) {
+            throw new Exception('One ShipStation requires the xml extension to be installed.');
         }
 
         return true;

--- a/OneShipStationPlugin.php
+++ b/OneShipStationPlugin.php
@@ -44,7 +44,7 @@ class OneShipStationPlugin extends BasePlugin {
             throw new Exception('One ShipStation requires Craft Commerce 1.0+.');
         }
 
-        if (extension_loaded('xml')) {
+        if (!extension_loaded('xml')) {
             throw new Exception('One ShipStation requires the xml extension to be installed.');
         }
     }

--- a/OneShipStationPlugin.php
+++ b/OneShipStationPlugin.php
@@ -28,7 +28,7 @@ class OneShipStationPlugin extends BasePlugin {
         return 'https://onedesigncompany.com';
     }
 
-    public function onBeforeInstall() {
+    protected function doDepChecks() {
         // require Craft 2.5+
         if (version_compare(craft()->getVersion(), '2.5', '<')) {
             throw new Exception('One ShipStation requires Craft CMS 2.5+ in order to run.');
@@ -44,10 +44,13 @@ class OneShipStationPlugin extends BasePlugin {
             throw new Exception('One ShipStation requires Craft Commerce 1.0+.');
         }
 
-        if (!extension_loaded('xml')) {
+        if (extension_loaded('xml')) {
             throw new Exception('One ShipStation requires the xml extension to be installed.');
         }
+    }
 
+    public function onBeforeInstall() {
+        $this->doDepChecks();
         return true;
     }
 
@@ -58,6 +61,10 @@ class OneShipStationPlugin extends BasePlugin {
     public function createTables() {}
 
     public function dropTables() {}
+
+    public function init() {
+        $this->doDepChecks();
+    }
 
     /*
      * WARNING: Do not register any routes that ShipStation will use here.

--- a/controllers/OneShipStation_OrdersController.php
+++ b/controllers/OneShipStation_OrdersController.php
@@ -26,6 +26,9 @@ class Oneshipstation_OrdersController extends BaseController
                 default:
                     throw new HttpException(400);
             }
+        } catch (ErrorException $e) {
+            Craft::log($e->getMessage(), LogLevel::Error, true);
+            return $this->returnErrorJson($e->getMessage());
         } catch (Exception $e) {
             Craft::log($e->getMessage(), LogLevel::Error, true);
             return $this->returnErrorJson($e->getMessage());

--- a/controllers/OneShipStation_OrdersController.php
+++ b/controllers/OneShipStation_OrdersController.php
@@ -84,9 +84,6 @@ class Oneshipstation_OrdersController extends BaseController
         $start_date = $this->parseDate('start_date');
         $end_date = $this->parseDate('end_date');
 
-        $myArray = [];
-        $myArray->error;
-
         if ($start_date && $end_date) {
             $criteria->dateOrdered = array('and', '> '.$start_date, '< '.$end_date);
         }

--- a/controllers/OneShipStation_OrdersController.php
+++ b/controllers/OneShipStation_OrdersController.php
@@ -29,15 +29,15 @@ class Oneshipstation_OrdersController extends BaseController
         } catch (ErrorException $e) {
             OneShipStationPlugin::log($e->getMessage(), LogLevel::Error, true);
             return $this->returnErrorJson($e->getMessage());
-        } catch (Exception $e) {
-            OneShipStationPlugin::log($e->getMessage(), LogLevel::Error, true);
-            return $this->returnErrorJson($e->getMessage());
         } catch (HttpException $e) {
             OneShipStationPlugin::log($e->getMessage(), LogLevel::Error, true);
             return $this->returnErrorJson(array(
                 'code' => $e->statusCode,
                 'error' => $e->getMessage(),
             ));
+        } catch (Exception $e) {
+            OneShipStationPlugin::log($e->getMessage(), LogLevel::Error, true);
+            return $this->returnErrorJson($e->getMessage());
         }
     }
 

--- a/controllers/OneShipStation_OrdersController.php
+++ b/controllers/OneShipStation_OrdersController.php
@@ -15,6 +15,7 @@ class Oneshipstation_OrdersController extends BaseController
      */
     public function actionProcess(array $variables=[]) {
         if (!$this->authenticate()) {
+            return $this->returnErrorJson('Invalid username/password.');
             throw new HttpException(401);
         }
         try {

--- a/controllers/OneShipStation_OrdersController.php
+++ b/controllers/OneShipStation_OrdersController.php
@@ -11,7 +11,7 @@ class Oneshipstation_OrdersController extends BaseController
      */
     function handleError($severity, $message, $filename, $lineno) {
       if (error_reporting() & $severity) {
-        throw new ErrorException($message, $severity);
+        throw new ErrorException(implode(array($message, basename($filename), $lineno), ': '), $severity);
       }
     }
 

--- a/controllers/OneShipStation_OrdersController.php
+++ b/controllers/OneShipStation_OrdersController.php
@@ -27,10 +27,10 @@ class Oneshipstation_OrdersController extends BaseController
                     throw new HttpException(400);
             }
         } catch (ErrorException $e) {
-            Craft::log($e->getMessage(), LogLevel::Error, true);
+            OneShipStationPlugin::log($e->getMessage(), LogLevel::Error, true);
             return $this->returnErrorJson($e->getMessage());
         } catch (Exception $e) {
-            Craft::log($e->getMessage(), LogLevel::Error, true);
+            OneShipStationPlugin::log($e->getMessage(), LogLevel::Error, true);
             return $this->returnErrorJson($e->getMessage());
         }
     }

--- a/controllers/OneShipStation_OrdersController.php
+++ b/controllers/OneShipStation_OrdersController.php
@@ -66,9 +66,14 @@ class Oneshipstation_OrdersController extends BaseController
      */
     protected function getOrders() {
         $criteria = craft()->elements->getCriteria('Commerce_Order');
-        if ($start_date = $this->parseDate('start_date') && $end_date = $this->parseDate('end_date')) {
+
+        $start_date = $this->parseDate('start_date');
+        $end_date = $this->parseDate('end_date');
+
+        if ($start_date && $end_date) {
             $criteria->dateOrdered = array('and', '> '.$start_date, '< '.$end_date);
         }
+
         $criteria->orderStatusId = true;
 
         $num_pages = $this->paginateOrders($criteria);

--- a/controllers/OneShipStation_OrdersController.php
+++ b/controllers/OneShipStation_OrdersController.php
@@ -15,8 +15,7 @@ class Oneshipstation_OrdersController extends BaseController
      */
     public function actionProcess(array $variables=[]) {
         if (!$this->authenticate()) {
-            return $this->returnErrorJson('Invalid username/password.');
-            throw new HttpException(401);
+            return $this->returnErrorJson('Invalid OneShipStation username or password.');
         }
         try {
             switch (craft()->request->getParam('action')) {
@@ -25,7 +24,7 @@ class Oneshipstation_OrdersController extends BaseController
                 case 'shipnotify':
                     return $this->postShipment();
                 default:
-                    throw new HttpException(400);
+                    throw new HttpException(400, 'No action set. Set the ?action= parameter as `export` or `shipnotify`.');
             }
         } catch (ErrorException $e) {
             OneShipStationPlugin::log($e->getMessage(), LogLevel::Error, true);
@@ -33,6 +32,12 @@ class Oneshipstation_OrdersController extends BaseController
         } catch (Exception $e) {
             OneShipStationPlugin::log($e->getMessage(), LogLevel::Error, true);
             return $this->returnErrorJson($e->getMessage());
+        } catch (HttpException $e) {
+            OneShipStationPlugin::log($e->getMessage(), LogLevel::Error, true);
+            return $this->returnErrorJson(array(
+                'code' => $e->statusCode,
+                'error' => $e->getMessage(),
+            ));
         }
     }
 

--- a/services/OneShipStation_XmlService.php
+++ b/services/OneShipStation_XmlService.php
@@ -59,12 +59,13 @@ class OneShipStation_XmlService extends BaseApplicationComponent {
 
         $this->shippingMethod($order_xml, $order);
 
-        if ($paymentObj = $order->paymentMethod)
+        if ($paymentObj = $order->paymentMethod) {
             $this->addChildWithCDATA($order_xml, 'PaymentMethod', $paymentObj->name);
+        }
 
         $items_xml = $this->items($order_xml, $order->getLineItems());
         $this->discount($items_xml, $order);
-        
+
         $customer = $order->getCustomer();
         $customer_xml = $this->customer($order_xml, $customer);
 
@@ -135,7 +136,7 @@ class OneShipStation_XmlService extends BaseApplicationComponent {
                                                 'cdata' => false]
         ];
         $this->mapCraftModel($item_xml, $item_mapping, $item);
- 
+
         $item_xml->addChild('WeightUnits', 'Grams');
 
         if (isset($item->snapshot['options'])) {


### PR DESCRIPTION
- Forces exceptions to be logged
- Checks for xml extension to be loaded
- Returns JSON responses to ShipStation for better logging in ShipStation. Right now, it's just the header of the html page that is rendered in ShipStation.

* **Question**: One thing I'm not sure of is how ShipStation will respond to the way Craft handles `returnErrorJson()`, because Craft returns a 200 response with this method call. ShipStation may see that as a success.

Once reviewed, we need to create a new release on the master branch (v0.2.23).