### PR TITLE
Find SKU through snapshot rather than purchasable

### DIFF
--- a/services/OneShipStation_XmlService.php
+++ b/services/OneShipStation_XmlService.php
@@ -125,7 +125,7 @@ class OneShipStation_XmlService extends BaseApplicationComponent {
     public function item(\SimpleXMLElement $xml, Commerce_LineItemModel $item, $name='Item') {
         $item_xml = $xml->getName() == $name ? $xml : $xml->addChild($name);
 
-        $item_mapping = ['SKU'              => ['callback' => function($item) { return $item->getPurchasable()->sku; }],
+        $item_mapping = ['SKU'              => ['callback' => function($item) { return $item->snapshot['sku']; }],
                          'Name'             => 'description',
                          'Weight'           => ['callback' => function($item) { return round($item->weight, 2); },
                                                 'cdata' => false],


### PR DESCRIPTION
The line item maintains a `snapshot` of the `purchasable` at the time of purchase to protect from instances where a product has been deleted or changed since purchase. This switches our reference from a query through the `purchasable` item to pulling the `sku` from the `snapshot`.