### PR TITLE
Bugfix: order statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ craft/plugins/oneshipstation
 
 ## ShipStation Configuration
 
+### Order Statuses
+
+When ShipStation marks an order as shipped it calls back to Craft to update the order. This plugin assumes that there is an order status defined in Craft Commerce with the handle "shipped".
+
 ### Authentication
 
 Once you have configured your Craft application's OneShipStation, you will need to complete the process by configuring your [ShipStation "Custom Store" integration](https://help.shipstation.com/hc/en-us/articles/205928478-ShipStation-Custom-Store-Development-Guide#3a).

--- a/controllers/OneShipStation_OrdersController.php
+++ b/controllers/OneShipStation_OrdersController.php
@@ -72,13 +72,9 @@ class Oneshipstation_OrdersController extends BaseController
     }
 
     /**
-     * Renders a big XML file of all orders in a format described by ShipStation
-     * Note: this should probably get orders using Craft Commerce's variable/service if possible
+     * Returns a big XML object of all orders in a format described by ShipStation
      *
-     * @param DateTime $start
-     * @param DateTime $end
-     *
-     * @return Commerce_OrderModel[]|null
+     * @return SimpleXMLElement Orders XML
      */
     protected function getOrders() {
         $criteria = craft()->elements->getCriteria('Commerce_Order');
@@ -91,6 +87,9 @@ class Oneshipstation_OrdersController extends BaseController
 
         // null orderStatusId means the order is only a cart
         $criteria->orderStatusId = 'not null';
+
+        // Order the results to be consistent across pages
+        $criteria->order = 'dateOrdered asc';
 
         $num_pages = $this->paginateOrders($criteria);
 
@@ -146,8 +145,10 @@ class Oneshipstation_OrdersController extends BaseController
     }
 
     /**
-     * Updates order status for a given order, as posted here by ShipStation.
-     * The order is found using GET param order_number.
+     * Updates order status for a given order. This is called by ShipStation.
+     * The order is found using the query param `order_number`.
+     *
+     * TODO: This assumes there is a "shipped" handle for an order status
      *
      * See craft/plugins/commerce/controllers/Commerce_OrdersController.php#actionUpdateStatus() for details
      *
@@ -170,7 +171,7 @@ class Oneshipstation_OrdersController extends BaseController
                 throw new ErrorException('Logging shipping information failed for order ' . $order->id);
             }
 
-            $this->returnJson(['success' => true]); //TODO return 200 success
+            $this->returnJson(['success' => true]);
         } else {
             throw new ErrorException('Failed to save order with id ' . $order->id);
         }

--- a/controllers/OneShipStation_OrdersController.php
+++ b/controllers/OneShipStation_OrdersController.php
@@ -88,7 +88,9 @@ class Oneshipstation_OrdersController extends BaseController
         if ($start_date && $end_date) {
             $criteria->dateOrdered = array('and', '> '.$start_date, '< '.$end_date);
         }
-        $criteria->orderStatusId = true;
+
+        // null orderStatusId means the order is only a cart
+        $criteria->orderStatusId = 'not null';
 
         $num_pages = $this->paginateOrders($criteria);
 


### PR DESCRIPTION
The plugin was assuming the `processing` order status in the order query. `$criteria->orderStatusId = true;` was translated to `WHERE orderStatusId = 1` and not returning other orders.

Also, orders weren't being ordered in the results which could cause problems if orders are placed while ShipStation is importing orders.