### PR TITLE
PHP 7+: Only variables should be passed by reference

### DIFF
--- a/migrations/m160106_182029_oneshipstation_AddShipmentFields.php
+++ b/migrations/m160106_182029_oneshipstation_AddShipmentFields.php
@@ -22,10 +22,11 @@ class m160106_182029_oneshipstation_AddShipmentFields extends BaseMigration
        }
 
        //next, make sure the group exists. we can't create a field unless we have a group for it to belong to
-        $groupName = craft()->plugins->getPlugin('oneShipStation')->name;
-       $group = array_shift(array_filter(craft()->fields->getAllGroups(), function($group) use ($groupName) {
+       $groupName = craft()->plugins->getPlugin('oneShipStation')->name;
+       $matchingGroup = array_filter(craft()->fields->getAllGroups(), function ($group) use ($groupName) {
            return $group->name == $groupName;
-       }));
+       });
+       $group = array_shift($matchingGroup);
        if (is_null($group)) {
            $group = new FieldGroupModel();
            $group->name = $groupName;

--- a/migrations/m160106_195226_oneshipstation_AddShipmentFieldsToOrder.php
+++ b/migrations/m160106_195226_oneshipstation_AddShipmentFieldsToOrder.php
@@ -26,7 +26,8 @@ class m160106_195226_oneshipstation_AddShipmentFieldsToOrder extends BaseMigrati
 
                 //find or create One ShipStation tab
                 $shipstationTabName = craft()->plugins->getPlugin('oneShipStation')->name;
-                $shipstationTab = array_shift(array_filter($fieldLayout->getTabs(), function($tab) { return $tab->name == 'One ShipStation'; }));
+                $shipstationTabs = array_filter($fieldLayout->getTabs(), function($tab) { return $tab->name == 'One ShipStation'; });
+                $shipstationTab = array_shift($shipstationTabs);
 
                 //no tab found (this is most likely), so create tab and field record
                 if (!$shipstationTab) {


### PR DESCRIPTION
Ran into an issue where the migrations were failing to run because the `array_shift()` is trying to ship the result of an `array_filter()`. This is forbidden and throws an "Only variables should be passed by reference" error.