### PR TITLE
Custom order filtering for ShipStation import XML

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,35 @@ class MyPlugin extends BasePlugin {
 
 }
 ```
+### Customizing Order Export for ShipStation XML  
+
+When ShipStation imports orders from Craft Commerce it passes a start date and end date. By default, this plugin will poplulate the XML feed with orders where the dateOrdered field matches the requested date range. You can override the default behavior to filter by status, date updated, etc by using your own plugin to create an ElementCriteriaModel and return it.
+
+```
+class MyPlugin extends BasePlugin {
+
+    public function oneShipStationGetOrderCriteria($start_date, $end_date) 
+    {
+        $criteria = craft()->elements->getCriteria('Commerce_Order');
+
+        if (!empty($start_date) && !empty($end_date)) {
+            $criteria->updatedOn = array('and', '> ' . $start_date, '< ' . $end_date);
+        }
+
+        // null orderStatusId means the order is only a cart
+        $criteria->orderStatusId = 'not null';
+
+        // Get only the orders flagged as Received
+        $criteria->orderStatus = craft()->commerce_orderStatuses->getOrderStatusByHandle('received');
+
+        // Order the results to be consistent across pages
+        $criteria->order = 'dateOrdered asc';
+
+        return $criteria;
+    }
+
+}
+```
 
 
 ## Development

--- a/services/OneShipStation_XmlService.php
+++ b/services/OneShipStation_XmlService.php
@@ -198,7 +198,7 @@ class OneShipStation_XmlService extends BaseApplicationComponent {
             'Name'       => 'couponCode',
             'Quantity'   => ['callback' => function($order) { return 1; }, 'cdata' => false],
             'UnitPrice'  => [
-                'callback' => function($order) { return number_format($order->getTotalDiscount(), 2); },
+                'callback' => function($order) { return round($order->getTotalDiscount(), 2); },
                 'cdata' => false],
             'Adjustment' => ['callback' => function($order) { return 'true'; }, 'cdata' => false],
         ];

--- a/services/OneShipStation_XmlService.php
+++ b/services/OneShipStation_XmlService.php
@@ -340,7 +340,8 @@ class OneShipStation_XmlService extends BaseApplicationComponent {
                 foreach ($customFieldCallbacks as $callback) {
                     if (is_callable($callback)) {
                         $value = $callback($order);
-                        $order_xml->addChild($fieldName, substr(htmlspecialchars($value), 0, 1000));
+                        $strlen = (in_array($fieldName, ['CustomField1', 'CustomField2', 'CustomField3'])) ? 100: 1000;
+                        $order_xml->addChild($fieldName, substr(htmlspecialchars($value), 0, $strlen));
                     }
                 }
             }

--- a/services/OneShipStation_XmlService.php
+++ b/services/OneShipStation_XmlService.php
@@ -340,8 +340,12 @@ class OneShipStation_XmlService extends BaseApplicationComponent {
                 foreach ($customFieldCallbacks as $callback) {
                     if (is_callable($callback)) {
                         $value = $callback($order);
-                        $strlen = (in_array($fieldName, ['CustomField1', 'CustomField2', 'CustomField3'])) ? 100: 1000;
-                        $order_xml->addChild($fieldName, substr(htmlspecialchars($value), 0, $strlen));
+                        if (strpos($fieldName, 'CustomField') !== false) {
+                            $fieldLimit = 100;
+                        } else {
+                            $fieldLimit = 1000;
+                        }
+                        $order_xml->addChild($fieldName, substr(htmlspecialchars($value), 0, $fieldLimit));
                     }
                 }
             }

--- a/services/OneShipStation_XmlService.php
+++ b/services/OneShipStation_XmlService.php
@@ -340,7 +340,7 @@ class OneShipStation_XmlService extends BaseApplicationComponent {
                 foreach ($customFieldCallbacks as $callback) {
                     if (is_callable($callback)) {
                         $value = $callback($order);
-                        $order_xml->addChild($fieldName, substr(htmlspecialchars($value), 0, 100));
+                        $order_xml->addChild($fieldName, substr(htmlspecialchars($value), 0, 1000));
                     }
                 }
             }


### PR DESCRIPTION
I integrated this pull request https://github.com/onedesign/oneshipstation/pull/48 into my fork and then modified the order controller getOrders method to look for another plugin with a method named oneShipStationGetOrderCriteria. If the method exists, the returned ElementCriteriaModel will be used to find orders for the XML feed. If the user defined method is not found, then oneShipStation's default behavior won't change. I also updated the readme file to document the change. 